### PR TITLE
Fix cramped h4 titles inside boxes

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,13 +43,13 @@ nav a:active {
 }
 
 .color {
-    width: 140px;
+    width: 160px;
     height: 50px;
     display: inline-block;
     border: 2px solid #000;
     padding: 10px;
     padding-bottom: 25px;
-    margin: 5px;
+    margin: 5px 15px;
     color: white;
     line-height: 0.1em;
 }


### PR DESCRIPTION
The **< h4 >** that shows the *Pump & Power* text is displayed incorrectly, or it's cramped. By changing the box's width it has been fixed 

Before:
![image](https://github.com/jenniferlewmunoz/jens-style-guide/assets/80791406/9316d533-a4e2-49ef-84b6-840dd90c8893)

After:
![image](https://github.com/jenniferlewmunoz/jens-style-guide/assets/80791406/80f79b16-4fe0-4714-91f1-7869448e7337)
